### PR TITLE
chore: re-import "DefaultHasher"

### DIFF
--- a/cdn-proto/src/lib.rs
+++ b/cdn-proto/src/lib.rs
@@ -38,7 +38,7 @@ pub mod messages_capnp {
 
 /// A function for generating a cute little user mnemonic from a hash
 pub fn mnemonic(bytes: &UserPublicKey) -> String {
-    let mut state = std::hash::DefaultHasher::new();
+    let mut state = std::collections::hash_map::DefaultHasher::new();
     bytes.hash(&mut state);
     mnemonic::to_string(state.finish().to_le_bytes())
 }


### PR DESCRIPTION
As it's causing compilation failure in this working PR: https://github.com/EspressoSystems/HotShot/pull/2789

```
error[E0433]: failed to resolve: could not find `DefaultHasher` in `hash`
  --> /home/*/.cargo/git/checkouts/push-cdn-48e30484a1a51abd/f200933/cdn-proto/src/lib.rs:41:32
   |
41 |     let mut state = std::hash::DefaultHasher::new();
   |                                ^^^^^^^^^^^^^ could not find `DefaultHasher` in `hash`
   |
help: consider importing this struct
   |
6  + use std::collections::hash_map::DefaultHasher;
   |
help: if you import `DefaultHasher`, refer to it directly
   |
41 -     let mut state = std::hash::DefaultHasher::new();
41 +     let mut state = DefaultHasher::new();
   |
```