### PR TITLE
chore: bump `jf-primitives` to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,7 +2031,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "jf-primitives"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.4.1#e96464c4bd8beb608a6a4afc8b8a2441c981f21a"
+source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.4.2#f85f9024ef42ab8be95b2c81bd15fd6cbadeafbf"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -2076,7 +2076,7 @@ dependencies = [
 [[package]]
 name = "jf-relation"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.4.1#e96464c4bd8beb608a6a4afc8b8a2441c981f21a"
+source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.4.2#f85f9024ef42ab8be95b2c81bd15fd6cbadeafbf"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.4.0-pre.0"
-source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.4.1#e96464c4bd8beb608a6a4afc8b8a2441c981f21a"
+source = "git+https://github.com/EspressoSystems/jellyfish.git?tag=0.4.2#f85f9024ef42ab8be95b2c81bd15fd6cbadeafbf"
 dependencies = [
  "ark-ec",
  "ark-ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ package.description = "The PushCDN is a distributed, scalable, and fault-toleran
 
 [workspace.dependencies]
 tokio = { version = "1.35.1", features = ["full"] }
-jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.4.1" }
+jf-primitives = { git = "https://github.com/EspressoSystems/jellyfish.git", tag = "0.4.2" }
 rand = "0.8.5"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"


### PR DESCRIPTION
as title says