### PR TITLE
Kill reconnection on drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "cdn-proto",
  "clap",
  "jf-signature",
+ "parking_lot",
  "rand",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "ansi",
 ] }
 clap = { version = "4", features = ["derive"] }
+parking_lot = "0.12"
 prometheus = { version = "0.13", default-features = false }
 lazy_static = "1"
 async-std = { version = "1", default-features = false, features = [

--- a/cdn-broker/Cargo.toml
+++ b/cdn-broker/Cargo.toml
@@ -59,5 +59,5 @@ derivative.workspace = true
 dashmap = { version = "6", default-features = false }
 rand.workspace = true
 local-ip-address = "0.6"
-parking_lot = "0.12"
+parking_lot.workspace = true
 portpicker = "0.1"

--- a/cdn-client/Cargo.toml
+++ b/cdn-client/Cargo.toml
@@ -32,3 +32,4 @@ tracing-subscriber.workspace = true
 rand.workspace = true
 tracing.workspace = true
 clap.workspace = true
+parking_lot.workspace = true


### PR DESCRIPTION
Kills the reconnection task when the client is dropped so it doesn't run forever if it can never connect.