### PR TITLE
Fix never fallback warning.

### DIFF
--- a/cdn-proto/src/discovery/redis.rs
+++ b/cdn-proto/src/discovery/redis.rs
@@ -105,7 +105,7 @@ impl DiscoveryClient for Redis {
                     "EX".to_string(),
                     heartbeat_expiry.as_secs().to_string()
                 ])
-                .query_async(&mut self.underlying_connection)
+                .query_async::<()>(&mut self.underlying_connection)
                 .await,
             Connection,
             "failed to connect to Redis"
@@ -228,7 +228,7 @@ impl DiscoveryClient for Redis {
         bail!(
             cmd.arg(public_key)
                 .arg(&["EX", &expiry.as_secs().to_string()])
-                .query_async(&mut self.underlying_connection)
+                .query_async::<()>(&mut self.underlying_connection)
                 .await,
             Connection,
             "failed to connect to Redis"
@@ -286,7 +286,7 @@ impl DiscoveryClient for Redis {
         }
 
         bail!(
-            pipeline.query_async(&mut self.underlying_connection).await,
+            pipeline.query_async::<()>(&mut self.underlying_connection).await,
             Connection,
             "failed to query whitelist"
         );


### PR DESCRIPTION
The current fallback from `!` to `()` is being phased out, causing warnings such as this:

> warning: this function depends on never type fallback being `()`
> [...]
> = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
> = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
> = help: specify the types explicitly note: in edition 2024, the requirement `!: FromRedisValue` will fail

This PR specifies the expected type.